### PR TITLE
Add launchOptions, pass headers from website-scraper

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,9 +22,11 @@ const PuppeteerPlugin = require('website-scraper-puppeteer');
 scrape({
     urls: ['https://www.instagram.com/gopro/'],
     directory: '/path/to/save',
-    plugins: [ new PuppeteerPlugin() ]
+    plugins: [ new PuppeteerPlugin({launchOptions: {}}) ] 
 });
 ```
+Puppeteer plugin constructor accepts next params:
+* `launchOptions` - puppeteer launch options, can be found in [puppeteer docs](https://github.com/GoogleChrome/puppeteer/blob/v1.20.0/docs/api.md#puppeteerlaunchoptions)
 
 ## How it works
 It starts Chromium in headless mode which just opens page and waits until page is loaded.

--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ class PuppeteerPlugin {
 
 		registerAction('beforeRequest', async ({requestOptions}) => {
 			if (hasValues(requestOptions.headers)) {
-				this.headers = requestOptions.headers;
+				this.headers = Object.assign({}, requestOptions.headers);
 			}
 			return {requestOptions};
 		});


### PR DESCRIPTION
* Add `launchOptions` to constructor
* Use headers from main `website-scraper` request  in puppeteer
* Fix closing not existing browser

Fixes #2 
Cookies can be passed in `request.headers` option for `website-scraper` module. This headers will be passed to puppeteer
Example: 
```javascript
scrape({
	urls: ['https://example.com/'],
	directory: 'myDir',
	request: {
		headers: {
			cookie: 'token=123',
		}
	},
	plugins: [new PuppeteerPlugin()]
});
```