### PR TITLE
scroll to the bottom of the document before triggering page.content()

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,11 +22,17 @@ const PuppeteerPlugin = require('website-scraper-puppeteer');
 scrape({
     urls: ['https://www.instagram.com/gopro/'],
     directory: '/path/to/save',
-    plugins: [ new PuppeteerPlugin({launchOptions: {}}) ] 
+    plugins: [ new PuppeteerPlugin(
+        {launchOptions: {}},
+        {scrollToBottom: { timeout: 10000, viewportN: 10 }} /*optional*/
+    )]
 });
 ```
 Puppeteer plugin constructor accepts next params:
 * `launchOptions` - puppeteer launch options, can be found in [puppeteer docs](https://github.com/GoogleChrome/puppeteer/blob/v1.20.0/docs/api.md#puppeteerlaunchoptions)
+* `scrollToBottom` - *(optional)* - in some cases, the page needs to be scrolled down to render its assets (lazyloading). Because some pages can be really endless, the scrolldown process can be interrupted before reaching the bottom when one or both of the bellow limitations are reached :
+    * `timeout` - in milliseconds
+    * `viewportN` - viewportheight multiplier
 
 ## How it works
 It starts Chromium in headless mode which just opens page and waits until page is loaded.

--- a/index.js
+++ b/index.js
@@ -30,6 +30,7 @@ class PuppeteerPlugin {
 					await page.setExtraHTTPHeaders(this.headers);
 				}
 				await page.goto(url);
+				await scrollToBottom(page);
 				const content = await page.content();
 				await page.close();
 				return content;
@@ -44,6 +45,25 @@ class PuppeteerPlugin {
 
 function hasValues(obj) {
 	return obj && Object.keys(obj).length > 0;
+}
+
+async function scrollToBottom(page) {
+	await page.evaluate(async () => {
+		await new Promise((resolve, reject) => {
+			let totalHeight = 0
+			let distance = 50
+			let timer = setInterval(() => {
+				let scrollHeight = document.body.scrollHeight
+				window.scrollBy(0, distance)
+				totalHeight += distance
+
+				if(totalHeight >= scrollHeight) {
+					clearInterval(timer)
+					resolve()
+				}
+			}, 50)
+		})
+	})
 }
 
 module.exports = PuppeteerPlugin;


### PR DESCRIPTION
On many websites, images are lazyloaded.
Even if the downloaded pages are ok (as long as you also scrape the JS, the lazyloading feature keeps working), a big part of the images "src" attributes is filled with an absolute path from some external host, cdn or original website.

cons : 
- a lot of missing elements when reading the pages offline
- the images may eventually expire


Scrolling down before scraping avoid this.