### PR TITLE
Convert html content to binary to preserve special characters

### DIFF
--- a/index.js
+++ b/index.js
@@ -41,7 +41,7 @@ class PuppeteerPlugin {
 
 				const content = await page.content();
 				await page.close();
-				return content;
+				return Buffer.from(content).toString('binary');
 			} else {
 				return response.body;
 			}

--- a/index.js
+++ b/index.js
@@ -41,6 +41,7 @@ class PuppeteerPlugin {
 
 				const content = await page.content();
 				await page.close();
+				// convert utf-8 -> binary string because website-scraper needs binary
 				return Buffer.from(content).toString('binary');
 			} else {
 				return response.body;


### PR DESCRIPTION
This PR fixes the issue with special characters and encodings like Latin, Korean, not being saved correctly to the file system as reported on issue #7 

It uses the same solution as https://github.com/website-scraper/node-website-scraper-phantom/blob/299c60d536911a6633ea0ae99547a0844c68afaf/src/get-phantom-html.js#L25 reported on website-scraper/node-website-scraper#379

node-website-scraper expects the page to be in binary. Not doing so leads to incorrect charset encoding on the downloaded pages. 
