### PR TITLE
Remove binary encoding to preserve special characters.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -53,8 +53,7 @@ class PuppeteerPlugin {
 				const content = await page.content();
 				await page.close();
 
-				// convert utf-8 -> binary string because website-scraper needs binary
-				return Buffer.from(content).toString('binary');
+				return Buffer.from(content).toString();
 			} else {
 				return response.body;
 			}


### PR DESCRIPTION
This PR fixes the issue created when attempting to fix special characters in April. See #13 #7

Although node-website-scraper expects the page to be in binary, it seems the prior fix now creates the same issues.

See the m-dashes (—) on https://stripe.com/en-gb-ca for testing.