### PR TITLE
Add gotoOptions param and update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,7 +28,7 @@ await scrape({
     plugins: [ 
       new PuppeteerPlugin({
         launchOptions: { headless: false }, /* optional */
-        gotoOptions: { waitUntil: "networkIdle0" }, /* optional */
+        gotoOptions: { waitUntil: "networkidle0" }, /* optional */
         scrollToBottom: { timeout: 10000, viewportN: 10 }, /* optional */
         blockNavigation: true, /* optional */
       })
@@ -36,8 +36,8 @@ await scrape({
 });
 ```
 Puppeteer plugin constructor accepts next params:
-* `launchOptions` - *(optional)* - puppeteer launch options, can be found in [puppeteer docs](https://github.com/puppeteer/puppeteer/blob/v13.0.1/docs/api.md#puppeteerlaunchoptions)
-* `gotoOptions` - *(optional)* - puppeteer page.goto options, can be found in [puppeteer docs](https://github.com/puppeteer/puppeteer/blob/v13.0.1/docs/api.md#framegotourl-options)
+* `launchOptions` - *(optional)* - puppeteer launch options, can be found in [puppeteer docs](https://github.com/puppeteer/puppeteer/blob/puppeteer-v20.2.0/docs/api/puppeteer.puppeteerlaunchoptions.md)
+* `gotoOptions` - *(optional)* - puppeteer page.goto options, can be found in [puppeteer docs](https://github.com/puppeteer/puppeteer/blob/puppeteer-v20.2.0/docs/api/puppeteer.frame.goto.md#parameters)
 * `scrollToBottom` - *(optional)* - in some cases, the page needs to be scrolled down to render its assets (lazyloading). Because some pages can be really endless, the scrolldown process can be interrupted before reaching the bottom when one or both of the bellow limitations are reached:
     * `timeout` - in milliseconds
     * `viewportN` - viewport height multiplier

--- a/README.md
+++ b/README.md
@@ -28,6 +28,7 @@ await scrape({
     plugins: [ 
       new PuppeteerPlugin({
         launchOptions: { headless: false }, /* optional */
+        gotoOptions: { waitUntil: "networkIdle0" }, /* optional */
         scrollToBottom: { timeout: 10000, viewportN: 10 }, /* optional */
         blockNavigation: true, /* optional */
       })
@@ -36,6 +37,7 @@ await scrape({
 ```
 Puppeteer plugin constructor accepts next params:
 * `launchOptions` - *(optional)* - puppeteer launch options, can be found in [puppeteer docs](https://github.com/puppeteer/puppeteer/blob/v13.0.1/docs/api.md#puppeteerlaunchoptions)
+* `gotoOptions` - *(optional)* - puppeteer page.goto options, can be found in [puppeteer docs](https://github.com/puppeteer/puppeteer/blob/v13.0.1/docs/api.md#framegotourl-options)
 * `scrollToBottom` - *(optional)* - in some cases, the page needs to be scrolled down to render its assets (lazyloading). Because some pages can be really endless, the scrolldown process can be interrupted before reaching the bottom when one or both of the bellow limitations are reached:
     * `timeout` - in milliseconds
     * `viewportN` - viewport height multiplier

--- a/lib/index.js
+++ b/lib/index.js
@@ -5,10 +5,12 @@ import scrollToBottomBrowser from './browserUtils/scrollToBottom.js';
 class PuppeteerPlugin {
 	constructor ({
 		launchOptions = {},
+		gotoOptions = {},
 		scrollToBottom = null,
 		blockNavigation = false
 	} = {}) {
 		this.launchOptions = launchOptions;
+		this.gotoOptions = gotoOptions;
 		this.scrollToBottom = scrollToBottom;
 		this.blockNavigation = blockNavigation;
 		this.browser = null;
@@ -45,7 +47,7 @@ class PuppeteerPlugin {
 					await blockNavigation(page, url);
 				}
 
-				await page.goto(url);
+				await page.goto(url, this.gotoOptions);
 
 				if (this.scrollToBottom) {
 					await scrollToBottom(page, this.scrollToBottom.timeout, this.scrollToBottom.viewportN);


### PR DESCRIPTION
This PR allows one to include the following code that configures puppeteer to wait until "networkIdle0". This fixes the issue I had, where I wasn't able to configure the "waitUntil" prop.  

```js
new PuppeteerPlugin({
  // ....
  gotoOptions: { waitUntil: "networkIdle0" },
})
```