### PR TITLE
Lock puppeteer to version 20.1.*

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "debug": "^4.1.1",
-    "puppeteer": "^20.1.1"
+    "puppeteer": "20.1.*"
   },
   "peerDependencies": {
     "website-scraper": "^5.0.0"


### PR DESCRIPTION
Puppeteer supports only maintained LTS versions.
Started from ^20.2 it uses `btoa` ([commit](https://github.com/puppeteer/puppeteer/blame/f342a129e8f3760c8ce9e0f3ccec104a6fa889f2/packages/puppeteer-core/src/common/util.ts#L198)) which is available from nodejs 16