### PR TITLE
fix unicode error

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -57,7 +57,11 @@ class PuppeteerPlugin {
 				await page.close();
 
 				// convert utf-8 -> binary string because website-scraper needs binary
-				return Buffer.from(content).toString('binary');
+				// https://github.com/website-scraper/node-website-scraper?tab=readme-ov-file#afterresponse: (binary) This is advised against because of the binary assumption being made can foul up saving of utf8 responses to the filesystem.
+				return {
+					body: content,
+					encoding: 'utf8'
+				}
 			} else {
 				return response.body;
 			}

--- a/lib/index.js
+++ b/lib/index.js
@@ -61,7 +61,7 @@ class PuppeteerPlugin {
 				return {
 					body: content,
 					encoding: 'utf8'
-				}
+				};
 			} else {
 				return response.body;
 			}


### PR DESCRIPTION
Source: https://github.com/website-scraper/node-website-scraper?tab=readme-ov-file#afterresponse.
> a binary string. This is advised against because of the binary assumption being made can foul up saving of utf8 responses to the filesystem.

Test page: `http://www.csxykj.com/mobile/index.html`

Before:  `<h3>磁致伸缩位移�&nbsp;感器</h3>`, `<h5>影响大跨度桥梁施工控制的�&nbsp;�&nbsp;</h5>`.

After: `<h3>磁致伸缩位移传感器</h3>`, `<h5>影响大跨度桥梁施工控制的因素</h5>`.

