### PR TITLE
Replace direct puppeteer dependency with wrapper

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-import puppeteer from 'puppeteer';
+import puppeteer from 'website-scraper-puppeteer-version-bridge';
 import logger from './logger.js';
 import scrollToBottomBrowser from './browserUtils/scrollToBottom.js';
 

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "debug": "^4.1.1",
-    "website-scraper-puppeteer-compatibility-bridge": "github:website-scraper/website-scraper-puppeteer-compatibility-bridge#main"
+    "website-scraper-puppeteer-version-bridge": "github:website-scraper/website-scraper-puppeteer-version-bridge#add-export"
   },
   "peerDependencies": {
     "website-scraper": "^5.0.0"

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   ],
   "dependencies": {
     "debug": "^4.1.1",
-    "puppeteer": "^23.0.*"
+    "website-scraper-puppeteer-compatibility-bridge": "github:website-scraper/website-scraper-puppeteer-compatibility-bridge#main"
   },
   "peerDependencies": {
     "website-scraper": "^5.0.0"


### PR DESCRIPTION
# Problem
All released versions of the [website-scraper-puppeteer](https://www.npmjs.com/package/website-scraper-puppeteer) module adhere to a specific major version of Puppeteer. Puppeteer releases versions quickly, and the current version of the module([v1.1.0](https://github.com/website-scraper/website-scraper-puppeteer/releases/tag/v1.1.0)) uses puppeteer `20.2.*` which is [deprecated and unsupported](https://www.npmjs.com/package/puppeteer/v/20.2.1)

# Solutions
To handle this problem, 2 possible solutions were proposed

## Solution 1
Release a new version of `website-scraper-puppeteer` every time `puppeteer` is released.

## Solution 2
Introduce a separate wrapper module that will cover dependency updates on its own, without requiring releases of this module.

# Decision
Solution 2 was chosen to solve the problem.

It's done by introducing the separate wrapper module ([website-scraper-puppeteer-version-bridge](https://github.com/website-scraper/website-scraper-puppeteer-version-bridge/)), which automatically releases a new minor version with updated puppeteer dependency after the tests pass.

Let's call the wrapper module just _bridge module_

## Details
`website-scraper-puppeteer` will depend on `website-scraper-puppeteer-version-bridge@^1.0`.

`website-scraper-puppeteer-version-bridge` will automatically check for the new versions of `puppeteer` using the Dependabot. PR is automatically merged after the tests are green. 
Merging to the main will trigger the publishing of the new version of the bridge module on NPM.
It allows us to be sure that the module works properly with the latest versions of `puppeteer`

## What if tests fail?
In case tests fail and the BC-compatible fix could be implemented, it will be done within 1.x versions of the bridge module.
In case a BC-compatible fix cannot be released, the next major version of the bridge module will be released, and the requirement will be bumped in this module.