### PR TITLE
Drop support of "blockNavigation" option

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,6 @@ await scrape({
         launchOptions: { headless: "new" }, /* optional */
         gotoOptions: { waitUntil: "networkidle0" }, /* optional */
         scrollToBottom: { timeout: 10000, viewportN: 10 }, /* optional */
-        blockNavigation: true, /* optional */
       })
     ]
 });
@@ -41,7 +40,6 @@ Puppeteer plugin constructor accepts next params:
 * `scrollToBottom` - *(optional)* - in some cases, the page needs to be scrolled down to render its assets (lazyloading). Because some pages can be really endless, the scrolldown process can be interrupted before reaching the bottom when one or both of the bellow limitations are reached:
     * `timeout` - in milliseconds
     * `viewportN` - viewport height multiplier
-* `blockNavigation` - *(optional)* - defines whether navigation away from the page is permitted or not. If it is set to true, then the page is locked to the current url and redirects with `location.replace(anotherPage)` will not pass. Defaults to `false`
 
 ## How it works
 It starts Chromium in headless mode which just opens page and waits until page is loaded.

--- a/lib/index.js
+++ b/lib/index.js
@@ -7,16 +7,14 @@ class PuppeteerPlugin {
 		launchOptions = {},
 		gotoOptions = {},
 		scrollToBottom = null,
-		blockNavigation = false
 	} = {}) {
 		this.launchOptions = launchOptions;
 		this.gotoOptions = gotoOptions;
 		this.scrollToBottom = scrollToBottom;
-		this.blockNavigation = blockNavigation;
 		this.browser = null;
 		this.headers = {};
 
-		logger.info('init plugin', { launchOptions, scrollToBottom, blockNavigation });
+		logger.info('init plugin', { launchOptions, scrollToBottom });
 	}
 
 	apply (registerAction) {
@@ -41,10 +39,6 @@ class PuppeteerPlugin {
 				if (hasValues(this.headers)) {
 					logger.info('set headers to puppeteer page', this.headers);
 					await page.setExtraHTTPHeaders(this.headers);
-				}
-
-				if (this.blockNavigation) {
-					await blockNavigation(page, url);
 				}
 
 				await page.goto(url, this.gotoOptions);
@@ -76,19 +70,6 @@ async function scrollToBottom (page, timeout, viewportN) {
 	logger.info(`scroll puppeteer page to bottom ${viewportN} times with timeout = ${timeout}`);
 
 	await page.evaluate(scrollToBottomBrowser, timeout, viewportN);
-}
-
-async function blockNavigation (page, url) {
-	logger.info(`block navigation for puppeteer page from url ${url}`);
-
-	page.on('request', req => {
-		if (req.isNavigationRequest() && req.frame() === page.mainFrame() && req.url() !== url) {
-			req.abort('aborted');
-		} else {
-			req.continue();
-		}
-	});
-	await page.setRequestInterception(true);
 }
 
 export default PuppeteerPlugin;

--- a/test/puppeteer-plugin.test.js
+++ b/test/puppeteer-plugin.test.js
@@ -42,31 +42,6 @@ describe('Puppeteer plugin test', () => {
 			expect(content).to.contain('<div id="special-characters-test">7년 동안 한국에서 살았어요. Слава Україні!</div>');
 		});
 	});
-
-	describe('Block navigation', () => {
-		before('scrape website', async () => {
-			result = await scrape({
-				urls: [`http://localhost:${SERVE_WEBSITE_PORT}/navigation.html`],
-				directory: directory,
-				plugins: [
-					new PuppeteerPlugin({
-						launchOptions: { headless: "new" },
-						blockNavigation: true
-					})
-				]
-			});
-		});
-		before('get content from file', () => {
-			content = fs.readFileSync(`${directory}/${result[0].filename}`).toString();
-		});
-		after('delete dir', () => fs.removeSync(directory));
-
-		it('should render content (and not be redirected)', async () => {
-			expect(content).to.contain('<div id="root">Navigation blocked!</div>');
-		});
-	});
-
-
 });
 
 function startWebserver(port = 3000) {


### PR DESCRIPTION
It was checked in https://github.com/website-scraper/puppeteer-version-wrapper/pull/17 that puppeteer (actually most probably underlying Chromium) changed the behaviour starting from puppeteer version 24.1.0.

[Current implementation](https://github.com/website-scraper/website-scraper-puppeteer/blob/147abab13866aef4522678a02febaef1c8cf658c/lib/index.js#L81-L92) no longer prevents the main request from the redirect and the page is anyway redirected.

<details><summary>Old behaviour</summary>
<p>

<img width="1204" height="717" alt="Old behaviour" src="https://github.com/user-attachments/assets/60d46836-a648-428e-85c6-f329cbc50872" />


</p>
</details> 

<details><summary>New behaviour</summary>
<p>

<img width="1347" height="717" alt="New behaviour" src="https://github.com/user-attachments/assets/9548a22f-cef2-4198-b331-d7bda91dc450" />


</p>
</details> 