### PR TITLE
Save puppeteer HTML response as utf8 instead of a binary string

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -50,8 +50,14 @@ class PuppeteerPlugin {
 				const content = await page.content();
 				await page.close();
 
-				// convert utf-8 -> binary string because website-scraper needs binary
-				return Buffer.from(content).toString('binary');
+				// page.content() returns an already-decoded string, so we
+				// tell website-scraper to save it as utf8. Returning a binary
+				// string instead corrupts non-latin1 characters on disk.
+				// See https://github.com/website-scraper/node-website-scraper#afterresponse
+				return {
+					body: content,
+					encoding: 'utf8'
+				};
 			} else {
 				return response.body;
 			}

--- a/test/mock/cjk.html
+++ b/test/mock/cjk.html
@@ -1,0 +1,23 @@
+<!DOCTYPE html>
+<html lang="zh">
+<head>
+	<meta http-equiv="Content-Type" content="text/html; charset=utf-8">
+	<title>CJK test</title>
+</head>
+<body>
+
+<div id="cjk-characters-test"></div>
+
+<script>
+	// Reproduces https://github.com/website-scraper/website-scraper-puppeteer/pull/103
+	// Like the reported page, utf-8 is declared only via the http-equiv <meta>
+	// tag (not the Content-Type header). puppeteer still decodes it correctly,
+	// but saving page.content() as a binary string corrupts the CJK characters
+	// on disk, e.g. `磁致伸缩位移传感器` becomes `磁致伸缩位移�&nbsp;感器`.
+	window.onload = function() {
+		document.getElementById('cjk-characters-test').innerText = '磁致伸缩位移传感器 影响大跨度桥梁施工控制的因素';
+	};
+</script>
+
+</body>
+</html>

--- a/test/puppeteer-plugin.test.js
+++ b/test/puppeteer-plugin.test.js
@@ -42,11 +42,40 @@ describe('Puppeteer plugin test', () => {
 			expect(content).to.contain('<div id="special-characters-test">7년 동안 한국에서 살았어요. Слава Україні!</div>');
 		});
 	});
+
+	describe('CJK content with charset only in meta tag', () => {
+		let cjkResult, cjkContent;
+
+		before('scrape website', async () => {
+			cjkResult = await scrape({
+				urls: [`http://localhost:${SERVE_WEBSITE_PORT}/cjk.html`],
+				directory: directory,
+				plugins: [ new PuppeteerPlugin() ]
+			});
+		});
+		before('get content from file', () => {
+			cjkContent = fs.readFileSync(`${directory}/${cjkResult[0].filename}`).toString();
+		});
+		after('delete dir', () => fs.removeSync(directory));
+
+		// Regression test for https://github.com/website-scraper/website-scraper-puppeteer/pull/103
+		// Saving the page as a binary string corrupted these characters on disk.
+		it('should save CJK characters without corruption', () => {
+			expect(cjkContent).to.contain('<div id="cjk-characters-test">磁致伸缩位移传感器 影响大跨度桥梁施工控制的因素</div>');
+		});
+	});
 });
 
 function startWebserver(port = 3000) {
 	const serve = serveStatic('./test/mock', {'index': ['index.html']});
 	const server = http.createServer(function onRequest (req, res) {
+		// Serve the CJK page the same way as the website from #103: utf-8 is
+		// declared only in the html <meta> tag, not in the Content-Type header.
+		if (req.url === '/cjk.html') {
+			res.setHeader('Content-Type', 'text/html');
+			res.end(fs.readFileSync('./test/mock/cjk.html'));
+			return;
+		}
 		serve(req, res, finalhandler(req, res))
 	});
 


### PR DESCRIPTION
Fixes the unicode corruption reported in #103 (test page from that PR: `http://www.csxykj.com/mobile/index.html`).

### Problem
`page.content()` always returns a fully-decoded Unicode string, but the plugin converted it to a binary (latin1) string before handing it to `website-scraper`. That corrupted non-latin1 characters on disk, e.g. `磁致伸缩位移传感器` → `磁致伸缩位移�&nbsp;感器`.

### Fix
Return `{ body: content, encoding: 'utf8' }` so the already-decoded string is saved as utf8.

### Why not the header-based approach from #117
#117 derived the encoding from the response `Content-Type` header (mirroring the main module). That does **not** fix this case: the reported page serves `text/html` with **no charset** and declares utf-8 only via an old-style `<meta http-equiv="Content-Type" content="text/html; charset=utf-8">` tag. So `extractEncodingFromHeader` falls back to `binary` and reproduces the original corruption. Since `page.content()` is always a decoded string, utf8 is always the correct encoding to save.

### Test
Adds `test/mock/cjk.html`, served the same way as the reported page (utf-8 only in the `<meta>` tag, not the HTTP header). Verified the new test:
- ✅ passes with the utf8 fix
- ❌ fails on the old binary string code
- ❌ fails on #117's header-based approach

Closes #103 
Closes #117

🤖 Generated with [Claude Code](https://claude.com/claude-code)