### PR TITLE
ci: use latest npm version in tests

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -34,7 +34,13 @@ jobs:
         uses: actions/setup-node@v7
         with:
           node-version: ${{ matrix.node-version }}
+      - name: Update npm to latest
+        run: npm install -g npm@latest
       - run: npm i
+      - name: Install Chrome for Puppeteer
+        # npm v12 disables install scripts by default, so Puppeteer's
+        # postinstall no longer downloads Chrome automatically.
+        run: npx puppeteer browsers install chrome
       - name: Disable AppArmor
         if: ${{ matrix.os == 'ubuntu-latest' }}
         run: echo 0 | sudo tee /proc/sys/kernel/apparmor_restrict_unprivileged_userns

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -9,6 +9,9 @@ on:
     - cron: '17 2 * * *'
   workflow_dispatch: ~
 
+permissions:
+  contents: read
+
 jobs:
   test:
     timeout-minutes: 10
@@ -35,6 +38,9 @@ jobs:
         with:
           node-version: ${{ matrix.node-version }}
       - name: Update npm to latest
+        # npm@latest (v12+) dropped support for Node 20, so only upgrade on
+        # newer Node versions; Node 20 keeps its bundled npm.
+        if: ${{ matrix.node-version != 20 }}
         run: npm install -g npm@latest
       - run: npm i
       - name: Install Chrome for Puppeteer


### PR DESCRIPTION
## What

Updates the Node.js CI workflow to install the **latest npm** before running tests, and adds an explicit Chrome install step so tests keep working under it.

## Why

The tests currently rely on whatever npm ships with each Node version. Running against the latest npm exercises current behaviour — in particular **npm v12**, which disables install scripts by default. Under npm v12 Puppeteer's `postinstall` no longer downloads Chrome automatically, so tests would fail with `Could not find Chrome (ver. ...)` unless the browser is installed explicitly.

## Changes

- Add `npm install -g npm@latest` before `npm i`.
- Add an `npx puppeteer browsers install chrome` step after install to download the browser (needed because install scripts are off by default in npm v12+).

See the related README docs PR (#171) and Puppeteer's [automatic downloads can be blocked](https://pptr.dev/guides/installation#automatic-downloads-can-be-blocked) guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)