### PR TITLE
ci: fix zizmor findings in workflows

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
     - name: Checkout repository
       uses: actions/checkout@v7
+      with:
+        persist-credentials: false
 
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v4

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -33,6 +33,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v7
+        with:
+          persist-credentials: false
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v7
         with:

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -45,8 +45,11 @@ jobs:
         with:
           # Required to allow push to master without the checks/PR
           token: ${{ secrets.GH_PUSH_TOKEN }}
+          # Credentials must persist so the later "git push" step can authenticate
+          persist-credentials: true
 
       - name: Set up Node.js
+        # zizmor: ignore[cache-poisoning] - caching is not enabled (no `cache` input), so no cache is restored into this release build
         uses: actions/setup-node@v7
         with:
           node-version: '24'
@@ -73,11 +76,12 @@ jobs:
       - name: Bump version and create tag
         id: bump-version
         env:
+          BUMP: ${{ github.event.inputs.bump }}
           PREID_FLAG: ${{ startsWith(inputs.bump, 'pre') && inputs.preid && format('--preid {0}', inputs.preid) || '' }}
         run: |
           git config --global user.name "github-actions[bot]"
           git config --global user.email "github-actions[bot]@users.noreply.github.com"
-          TAG=$(npm version ${{ github.event.inputs.bump }} $PREID_FLAG -m "Release %s")
+          TAG=$(npm version "$BUMP" $PREID_FLAG -m "Release %s")
           echo "Created tag: $TAG"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
 

--- a/.github/workflows/sponsors.yml
+++ b/.github/workflows/sponsors.yml
@@ -14,6 +14,8 @@ jobs:
         with:
           # Required to allow push to master without the checks/PR
           token: ${{ secrets.GH_PUSH_TOKEN }}
+          # Credentials must persist so the later "git push" step can authenticate
+          persist-credentials: true
 
       - name: Generate Sponsors 💖
         uses: JamesIves/github-sponsors-readme-action@2fd9142e765f755780202122261dc85e78459405 # v1.6.0


### PR DESCRIPTION
Resolves three zizmor audits flagged by Qlty: `template-injection`, `cache-poisoning`, and `artipacked`.

## Changes

**artipacked** (credential persistence via artifacts) — set `persist-credentials` on every `actions/checkout`:
- `node.js.yml`, `codeql.yml` → `false` (these jobs never push)
- `publish.yml`, `sponsors.yml` → explicit `true`, since their later `git push origin master` relies on the persisted `GH_PUSH_TOKEN`

**template-injection** — `publish.yml`: pass `github.event.inputs.bump` through a `BUMP` env var and reference `"$BUMP"` in the run block, instead of interpolating the expression directly into the shell script.

**cache-poisoning** — `publish.yml`: `setup-node` has no `cache:` input, so no cache is restored into the release build. Suppressed the low-confidence finding with a scoped `# zizmor: ignore[cache-poisoning]` comment.

## Verification

`zizmor .github/workflows/` reports zero remaining `artipacked`, `template-injection`, or `cache-poisoning` findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)