### PR TITLE
ci: fix remaining zizmor cache-poisoning finding in publish.yml

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -49,8 +49,8 @@ jobs:
           persist-credentials: true
 
       - name: Set up Node.js
-        # zizmor: ignore[cache-poisoning] - caching is not enabled (no `cache` input), so no cache is restored into this release build
-        uses: actions/setup-node@v7
+        # caching is not enabled (no `cache` input), so no cache is restored into this release build
+        uses: actions/setup-node@v7 # zizmor: ignore[cache-poisoning]
         with:
           node-version: '24'
           registry-url: 'https://registry.npmjs.org'


### PR DESCRIPTION
Follow-up to #173. Qlty still reported `zizmor:zizmor/cache-poisoning` at `publish.yml:53` after that merge.

## Root cause

The `# zizmor: ignore[cache-poisoning]` comment was on the step's `name:` line. Qlty's zizmor version only honors an inline ignore on the **exact line the finding anchors to** — the `uses: actions/setup-node@v7` line — not the preceding `name:` line, so the finding kept firing.

## Fix

Move the suppression to a trailing comment on the `uses:` line (and keep the explanatory note above it). The finding is a false positive: `setup-node` has no `cache:` input, so no cache is restored into the release build.

## Verification

Ran Qlty locally against the change:

```
$ qlty check .github/workflows/publish.yml
✔ No issues
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)