### PR TITLE
fix: keep session cookies valid by syncing them with the browser cookie jar

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,6 +61,21 @@ Puppeteer plugin constructor accepts next params:
     * `timeout` - in milliseconds
     * `viewportN` - viewport height multiplier
 
+## Cookies
+Cookies passed in `request.headers.Cookie` (website-scraper option) are set into the browser's cookie jar, so pages opened in puppeteer send them too.
+The jar is the source of truth afterwards: if the website rotates or refreshes cookies (via `Set-Cookie` or js executed on the page), the updated cookies are used for all subsequent requests.
+
+```javascript
+await scrape({
+    urls: ['https://example.com/'],
+    directory: '/path/to/save',
+    request: {
+        headers: { Cookie: 'session=abc123' }
+    },
+    plugins: [ new PuppeteerPlugin() ]
+});
+```
+
 ## How it works
 It starts Chromium in headless mode which just opens page and waits until page is loaded.
 It is far from ideal because probably you need to wait until some resource is loaded or click some button or log in. Currently this module doesn't support such functionality.

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ Puppeteer plugin constructor accepts next params:
     * `viewportN` - viewport height multiplier
 
 ## Cookies
-Cookies passed in `request.headers.Cookie` (website-scraper option) are set into the browser's cookie jar, so pages opened in puppeteer send them too.
+Cookies passed in `request.headers.Cookie` (website-scraper option) are set into the browser's cookie jar for the scraped urls' hosts (including their subdomains), so pages opened in puppeteer send them too — but they are not leaked to other domains.
 The jar is the source of truth afterwards: if the website rotates or refreshes cookies (via `Set-Cookie` or js executed on the page), the updated cookies are used for all subsequent requests.
 
 ```javascript

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,4 +1,5 @@
 import { URL } from 'url';
+import setCookieParser from 'set-cookie-parser';
 
 /**
  * Parses a request Cookie header ("name1=value1; name2=value2")
@@ -25,29 +26,30 @@ function parseCookieHeader (cookieHeader) {
  * Returns null for malformed values.
  */
 function parseSetCookieHeader (setCookieHeader, requestUrl) {
-	const parts = setCookieHeader.split(';');
-	const nameValue = parseNameValuePair(parts[0]);
-	if (!nameValue) {
+	// decodeValues: false keeps values verbatim, so they round-trip
+	// into the browser jar and back into Cookie headers unchanged
+	const parsed = setCookieParser.parseString(setCookieHeader, { decodeValues: false });
+	if (!parsed.name) {
 		return null;
 	}
 
 	const url = new URL(requestUrl);
-	const attributes = parseAttributes(parts.slice(1));
 	const cookie = {
-		name: nameValue.name,
-		value: nameValue.value,
-		domain: parseDomainAttribute(attributes.domain) || url.hostname,
-		path: parsePathAttribute(attributes.path) || defaultPath(url.pathname)
+		name: parsed.name,
+		value: parsed.value,
+		// a Domain attribute always makes the cookie available to subdomains
+		domain: parsed.domain ? ensureLeadingDot(parsed.domain) : url.hostname,
+		path: parsed.path && parsed.path.startsWith('/') ? parsed.path : defaultPath(url.pathname)
 	};
 
-	if ('secure' in attributes) {
+	if (parsed.secure) {
 		cookie.secure = true;
 	}
-	if ('httponly' in attributes) {
+	if (parsed.httpOnly) {
 		cookie.httpOnly = true;
 	}
 
-	const expires = parseExpiration(attributes);
+	const expires = parseExpiration(parsed);
 	if (expires !== null) {
 		cookie.expires = expires;
 	}
@@ -55,49 +57,17 @@ function parseSetCookieHeader (setCookieHeader, requestUrl) {
 	return cookie;
 }
 
-function parseNameValuePair (pair) {
-	const separatorIndex = pair.indexOf('=');
-	if (separatorIndex === -1) {
-		return null;
-	}
-	const name = pair.slice(0, separatorIndex).trim();
-	if (!name) {
-		return null;
-	}
-	return { name, value: pair.slice(separatorIndex + 1).trim() };
-}
-
-function parseAttributes (parts) {
-	const attributes = {};
-	for (const part of parts) {
-		const separatorIndex = part.indexOf('=');
-		const key = (separatorIndex === -1 ? part : part.slice(0, separatorIndex)).trim().toLowerCase();
-		attributes[key] = separatorIndex === -1 ? '' : part.slice(separatorIndex + 1).trim();
-	}
-	return attributes;
-}
-
-function parseDomainAttribute (domain) {
-	if (!domain) {
-		return null;
-	}
-	// a Domain attribute always makes the cookie available to subdomains
+function ensureLeadingDot (domain) {
 	return domain.startsWith('.') ? domain : `.${domain}`;
 }
 
-function parsePathAttribute (path) {
-	return path && path.startsWith('/') ? path : null;
-}
-
-function parseExpiration (attributes) {
+function parseExpiration ({maxAge, expires}) {
 	// Max-Age takes precedence over Expires (RFC 6265 5.3)
-	const maxAge = parseInt(attributes['max-age'], 10);
-	if (!isNaN(maxAge)) {
+	if (maxAge !== undefined) {
 		return Math.floor(Date.now() / 1000) + maxAge;
 	}
-	const expires = Date.parse(attributes.expires);
-	if (!isNaN(expires)) {
-		return Math.floor(expires / 1000);
+	if (expires && !isNaN(expires.getTime())) {
+		return Math.floor(expires.getTime() / 1000);
 	}
 	return null;
 }

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -1,0 +1,142 @@
+import { URL } from 'url';
+
+/**
+ * Parses a request Cookie header ("name1=value1; name2=value2")
+ * into a list of {name, value} pairs.
+ */
+function parseCookieHeader (cookieHeader) {
+	return cookieHeader.split(';')
+		.map(pair => {
+			const separatorIndex = pair.indexOf('=');
+			if (separatorIndex === -1) {
+				return null;
+			}
+			return {
+				name: pair.slice(0, separatorIndex).trim(),
+				value: pair.slice(separatorIndex + 1).trim()
+			};
+		})
+		.filter(cookie => cookie && cookie.name);
+}
+
+/**
+ * Parses a response Set-Cookie header into a puppeteer CookieData object.
+ * Attributes which don't affect scraping (SameSite, Priority, ...) are ignored.
+ * Returns null for malformed values.
+ */
+function parseSetCookieHeader (setCookieHeader, requestUrl) {
+	const parts = setCookieHeader.split(';');
+	const nameValuePair = parts[0];
+	const separatorIndex = nameValuePair.indexOf('=');
+	if (separatorIndex === -1) {
+		return null;
+	}
+	const name = nameValuePair.slice(0, separatorIndex).trim();
+	if (!name) {
+		return null;
+	}
+
+	const url = new URL(requestUrl);
+	const cookie = {
+		name,
+		value: nameValuePair.slice(separatorIndex + 1).trim(),
+		domain: url.hostname,
+		path: defaultPath(url.pathname)
+	};
+
+	let maxAge = null;
+	let expires = null;
+
+	for (const attribute of parts.slice(1)) {
+		const attributeSeparatorIndex = attribute.indexOf('=');
+		const key = (attributeSeparatorIndex === -1 ? attribute : attribute.slice(0, attributeSeparatorIndex)).trim().toLowerCase();
+		const value = attributeSeparatorIndex === -1 ? '' : attribute.slice(attributeSeparatorIndex + 1).trim();
+
+		switch (key) {
+			case 'domain':
+				if (value) {
+					// a Domain attribute always makes the cookie available to subdomains
+					cookie.domain = value.startsWith('.') ? value : `.${value}`;
+				}
+				break;
+			case 'path':
+				if (value.startsWith('/')) {
+					cookie.path = value;
+				}
+				break;
+			case 'max-age': {
+				const seconds = parseInt(value, 10);
+				if (!isNaN(seconds)) {
+					maxAge = seconds;
+				}
+				break;
+			}
+			case 'expires': {
+				const timestamp = Date.parse(value);
+				if (!isNaN(timestamp)) {
+					expires = Math.floor(timestamp / 1000);
+				}
+				break;
+			}
+			case 'secure':
+				cookie.secure = true;
+				break;
+			case 'httponly':
+				cookie.httpOnly = true;
+				break;
+			default:
+				break;
+		}
+	}
+
+	// Max-Age takes precedence over Expires (RFC 6265 5.3)
+	if (maxAge !== null) {
+		cookie.expires = Math.floor(Date.now() / 1000) + maxAge;
+	} else if (expires !== null) {
+		cookie.expires = expires;
+	}
+
+	return cookie;
+}
+
+/**
+ * Checks whether a cookie from the browser jar should be sent
+ * to the given url (RFC 6265 5.1.3 domain-match / 5.1.4 path-match).
+ */
+function cookieMatchesUrl (cookie, requestUrl) {
+	const url = new URL(requestUrl);
+
+	if (cookie.secure && url.protocol !== 'https:') {
+		return false;
+	}
+
+	if (cookie.domain.startsWith('.')) {
+		const domain = cookie.domain.slice(1);
+		if (url.hostname !== domain && !url.hostname.endsWith(`.${domain}`)) {
+			return false;
+		}
+	} else if (url.hostname !== cookie.domain) {
+		return false;
+	}
+
+	const path = cookie.path || '/';
+	return url.pathname === path ||
+		(url.pathname.startsWith(path) && (path.endsWith('/') || url.pathname[path.length] === '/'));
+}
+
+function serializeCookies (cookies) {
+	return cookies.map(cookie => `${cookie.name}=${cookie.value}`).join('; ');
+}
+
+/**
+ * Default cookie path for a Set-Cookie header without a Path attribute (RFC 6265 5.1.4)
+ */
+function defaultPath (pathname) {
+	if (!pathname.startsWith('/')) {
+		return '/';
+	}
+	const lastSlashIndex = pathname.lastIndexOf('/');
+	return lastSlashIndex === 0 ? '/' : pathname.slice(0, lastSlashIndex);
+}
+
+export { parseCookieHeader, parseSetCookieHeader, cookieMatchesUrl, serializeCookies };

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -74,11 +74,9 @@ function parseExpiration ({maxAge, expires}) {
 
 /**
  * Checks whether a cookie from the browser jar should be sent
- * to the given url (RFC 6265 5.1.3 domain-match / 5.1.4 path-match).
+ * to the given URL instance (RFC 6265 5.1.3 domain-match / 5.1.4 path-match).
  */
-function cookieMatchesUrl (cookie, requestUrl) {
-	const url = new URL(requestUrl);
-
+function cookieMatchesUrl (cookie, url) {
 	if (cookie.secure && url.protocol !== 'https:') {
 		return false;
 	}
@@ -92,7 +90,7 @@ function cookieMatchesUrl (cookie, requestUrl) {
 		return false;
 	}
 
-	const path = cookie.path || '/';
+	const path = cookie.path;
 	return url.pathname === path ||
 		(url.pathname.startsWith(path) && (path.endsWith('/') || url.pathname[path.length] === '/'));
 }
@@ -101,15 +99,25 @@ function serializeCookies (cookies) {
 	return cookies.map(cookie => `${cookie.name}=${cookie.value}`).join('; ');
 }
 
+function getCookieHeader (headers) {
+	const key = Object.keys(headers).find(isCookieHeaderName);
+	return key ? headers[key] : null;
+}
+
+function deleteCookieHeader (headers) {
+	Object.keys(headers).filter(isCookieHeaderName).forEach(key => delete headers[key]);
+}
+
+function isCookieHeaderName (headerName) {
+	return headerName.toLowerCase() === 'cookie';
+}
+
 /**
  * Default cookie path for a Set-Cookie header without a Path attribute (RFC 6265 5.1.4)
  */
 function defaultPath (pathname) {
-	if (!pathname.startsWith('/')) {
-		return '/';
-	}
 	const lastSlashIndex = pathname.lastIndexOf('/');
-	return lastSlashIndex === 0 ? '/' : pathname.slice(0, lastSlashIndex);
+	return lastSlashIndex <= 0 ? '/' : pathname.slice(0, lastSlashIndex);
 }
 
-export { parseCookieHeader, parseSetCookieHeader, cookieMatchesUrl, serializeCookies };
+export { parseCookieHeader, parseSetCookieHeader, cookieMatchesUrl, serializeCookies, getCookieHeader, deleteCookieHeader };

--- a/lib/cookies.js
+++ b/lib/cookies.js
@@ -26,77 +26,80 @@ function parseCookieHeader (cookieHeader) {
  */
 function parseSetCookieHeader (setCookieHeader, requestUrl) {
 	const parts = setCookieHeader.split(';');
-	const nameValuePair = parts[0];
-	const separatorIndex = nameValuePair.indexOf('=');
-	if (separatorIndex === -1) {
-		return null;
-	}
-	const name = nameValuePair.slice(0, separatorIndex).trim();
-	if (!name) {
+	const nameValue = parseNameValuePair(parts[0]);
+	if (!nameValue) {
 		return null;
 	}
 
 	const url = new URL(requestUrl);
+	const attributes = parseAttributes(parts.slice(1));
 	const cookie = {
-		name,
-		value: nameValuePair.slice(separatorIndex + 1).trim(),
-		domain: url.hostname,
-		path: defaultPath(url.pathname)
+		name: nameValue.name,
+		value: nameValue.value,
+		domain: parseDomainAttribute(attributes.domain) || url.hostname,
+		path: parsePathAttribute(attributes.path) || defaultPath(url.pathname)
 	};
 
-	let maxAge = null;
-	let expires = null;
-
-	for (const attribute of parts.slice(1)) {
-		const attributeSeparatorIndex = attribute.indexOf('=');
-		const key = (attributeSeparatorIndex === -1 ? attribute : attribute.slice(0, attributeSeparatorIndex)).trim().toLowerCase();
-		const value = attributeSeparatorIndex === -1 ? '' : attribute.slice(attributeSeparatorIndex + 1).trim();
-
-		switch (key) {
-			case 'domain':
-				if (value) {
-					// a Domain attribute always makes the cookie available to subdomains
-					cookie.domain = value.startsWith('.') ? value : `.${value}`;
-				}
-				break;
-			case 'path':
-				if (value.startsWith('/')) {
-					cookie.path = value;
-				}
-				break;
-			case 'max-age': {
-				const seconds = parseInt(value, 10);
-				if (!isNaN(seconds)) {
-					maxAge = seconds;
-				}
-				break;
-			}
-			case 'expires': {
-				const timestamp = Date.parse(value);
-				if (!isNaN(timestamp)) {
-					expires = Math.floor(timestamp / 1000);
-				}
-				break;
-			}
-			case 'secure':
-				cookie.secure = true;
-				break;
-			case 'httponly':
-				cookie.httpOnly = true;
-				break;
-			default:
-				break;
-		}
+	if ('secure' in attributes) {
+		cookie.secure = true;
+	}
+	if ('httponly' in attributes) {
+		cookie.httpOnly = true;
 	}
 
-	// Max-Age takes precedence over Expires (RFC 6265 5.3)
-	if (maxAge !== null) {
-		cookie.expires = Math.floor(Date.now() / 1000) + maxAge;
-	} else if (expires !== null) {
+	const expires = parseExpiration(attributes);
+	if (expires !== null) {
 		cookie.expires = expires;
 	}
 
 	return cookie;
+}
+
+function parseNameValuePair (pair) {
+	const separatorIndex = pair.indexOf('=');
+	if (separatorIndex === -1) {
+		return null;
+	}
+	const name = pair.slice(0, separatorIndex).trim();
+	if (!name) {
+		return null;
+	}
+	return { name, value: pair.slice(separatorIndex + 1).trim() };
+}
+
+function parseAttributes (parts) {
+	const attributes = {};
+	for (const part of parts) {
+		const separatorIndex = part.indexOf('=');
+		const key = (separatorIndex === -1 ? part : part.slice(0, separatorIndex)).trim().toLowerCase();
+		attributes[key] = separatorIndex === -1 ? '' : part.slice(separatorIndex + 1).trim();
+	}
+	return attributes;
+}
+
+function parseDomainAttribute (domain) {
+	if (!domain) {
+		return null;
+	}
+	// a Domain attribute always makes the cookie available to subdomains
+	return domain.startsWith('.') ? domain : `.${domain}`;
+}
+
+function parsePathAttribute (path) {
+	return path && path.startsWith('/') ? path : null;
+}
+
+function parseExpiration (attributes) {
+	// Max-Age takes precedence over Expires (RFC 6265 5.3)
+	const maxAge = parseInt(attributes['max-age'], 10);
+	if (!isNaN(maxAge)) {
+		return Math.floor(Date.now() / 1000) + maxAge;
+	}
+	const expires = Date.parse(attributes.expires);
+	if (!isNaN(expires)) {
+		return Math.floor(expires / 1000);
+	}
+	return null;
 }
 
 /**

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@ import { URL } from 'url';
 import puppeteer from '@website-scraper/puppeteer-version-wrapper';
 import logger from './logger.js';
 import scrollToBottomBrowser from './browserUtils/scrollToBottom.js';
-import { parseCookieHeader, parseSetCookieHeader, cookieMatchesUrl, serializeCookies } from './cookies.js';
+import { parseCookieHeader, parseSetCookieHeader, cookieMatchesUrl, serializeCookies, getCookieHeader, deleteCookieHeader } from './cookies.js';
 
 class PuppeteerPlugin {
 	constructor ({
@@ -15,27 +15,26 @@ class PuppeteerPlugin {
 		this.scrollToBottom = scrollToBottom;
 		this.browser = null;
 		this.headers = {};
-		this.cookieSeededHosts = new Set();
 
 		logger.info('init plugin', { launchOptions, scrollToBottom });
 	}
 
 	apply (registerAction) {
-		registerAction('beforeStart', async () => {
+		registerAction('beforeStart', async ({options}) => {
 			this.browser = await puppeteer.launch(this.launchOptions);
+			await this.seedBrowserCookies(options);
 		});
 
 		registerAction('beforeRequest', async ({resource, requestOptions}) => {
-			const url = resource.getUrl();
 			const headers = Object.assign({}, requestOptions.headers);
 
-			await this.seedBrowserCookies(url, headers);
-			await this.applyBrowserCookies(url, headers);
+			await this.applyBrowserCookies(resource.getUrl(), headers);
 
 			if (hasValues(headers)) {
 				// puppeteer pages receive cookies from the browser jar, not from headers,
 				// so that Cookie is not leaked to third-party requests made by the page
-				this.headers = omitCookieHeader(headers);
+				this.headers = Object.assign({}, headers);
+				deleteCookieHeader(this.headers);
 			}
 
 			return {requestOptions: Object.assign({}, requestOptions, {headers})};
@@ -82,26 +81,30 @@ class PuppeteerPlugin {
 
 	/**
 	 * Sets cookies from the configured Cookie request header into the browser jar,
-	 * so puppeteer pages send them too. Done once per host - afterwards the jar,
-	 * which receives rotated/refreshed cookies, is the source of truth.
+	 * so puppeteer pages send them too. Seeded once for the scraped urls' hosts
+	 * (including their subdomains) - afterwards the jar, which receives
+	 * rotated/refreshed cookies, is the source of truth.
 	 * See https://github.com/website-scraper/website-scraper-puppeteer/issues/115
 	 */
-	async seedBrowserCookies (url, headers) {
-		const hostname = new URL(url).hostname;
-		if (this.cookieSeededHosts.has(hostname)) {
-			return;
-		}
-		this.cookieSeededHosts.add(hostname);
-
-		const cookieHeader = getCookieHeader(headers);
+	async seedBrowserCookies (options) {
+		const cookieHeader = getCookieHeader((options.request && options.request.headers) || {});
 		if (!cookieHeader) {
 			return;
 		}
 
-		const cookies = parseCookieHeader(cookieHeader)
-			.map(({name, value}) => ({name, value, domain: hostname, path: '/'}));
+		const pairs = parseCookieHeader(cookieHeader);
+		const hostnames = new Set(options.urls.map(({url}) => new URL(url).hostname));
+		const cookies = [];
+		for (const hostname of hostnames) {
+			// leading dot makes the cookie available to subdomains of the scraped host
+			const domain = hostname.includes('.') ? `.${hostname}` : hostname;
+			for (const {name, value} of pairs) {
+				cookies.push({name, value, domain, path: '/'});
+			}
+		}
+
 		if (cookies.length > 0) {
-			logger.info(`seed browser cookies for host ${hostname}`, cookies.map(cookie => cookie.name));
+			logger.info(`seed browser cookies for ${Array.from(hostnames).join(', ')}`);
 			await this.browser.setCookie(...cookies);
 		}
 	}
@@ -112,7 +115,8 @@ class PuppeteerPlugin {
 	 * which invalidates the initially configured ones.
 	 */
 	async applyBrowserCookies (url, headers) {
-		const cookies = (await this.browser.cookies()).filter(cookie => cookieMatchesUrl(cookie, url));
+		const parsedUrl = new URL(url);
+		const cookies = (await this.browser.cookies()).filter(cookie => cookieMatchesUrl(cookie, parsedUrl));
 		if (cookies.length > 0) {
 			deleteCookieHeader(headers);
 			headers.cookie = serializeCookies(cookies);
@@ -129,12 +133,15 @@ class PuppeteerPlugin {
 			return;
 		}
 
-		const cookies = setCookieHeaders
-			.map(setCookieHeader => parseSetCookieHeader(setCookieHeader, response.url))
-			.filter(Boolean);
 		const now = Date.now() / 1000;
-		const alive = cookies.filter(cookie => cookie.expires === undefined || cookie.expires > now);
-		const expired = cookies.filter(cookie => cookie.expires !== undefined && cookie.expires <= now);
+		const alive = [];
+		const expired = [];
+		for (const setCookieHeader of setCookieHeaders) {
+			const cookie = parseSetCookieHeader(setCookieHeader, response.url);
+			if (cookie) {
+				(cookie.expires !== undefined && cookie.expires <= now ? expired : alive).push(cookie);
+			}
+		}
 
 		if (alive.length > 0) {
 			await this.browser.setCookie(...alive);
@@ -147,23 +154,6 @@ class PuppeteerPlugin {
 
 function hasValues (obj) {
 	return obj && Object.keys(obj).length > 0;
-}
-
-function getCookieHeader (headers) {
-	const key = Object.keys(headers).find(headerName => headerName.toLowerCase() === 'cookie');
-	return key ? headers[key] : null;
-}
-
-function deleteCookieHeader (headers) {
-	Object.keys(headers)
-		.filter(headerName => headerName.toLowerCase() === 'cookie')
-		.forEach(headerName => delete headers[headerName]);
-}
-
-function omitCookieHeader (headers) {
-	const result = Object.assign({}, headers);
-	deleteCookieHeader(result);
-	return result;
 }
 
 async function scrollToBottom (page, timeout, viewportN) {

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,6 +1,8 @@
+import { URL } from 'url';
 import puppeteer from '@website-scraper/puppeteer-version-wrapper';
 import logger from './logger.js';
 import scrollToBottomBrowser from './browserUtils/scrollToBottom.js';
+import { parseCookieHeader, parseSetCookieHeader, cookieMatchesUrl, serializeCookies } from './cookies.js';
 
 class PuppeteerPlugin {
 	constructor ({
@@ -13,6 +15,7 @@ class PuppeteerPlugin {
 		this.scrollToBottom = scrollToBottom;
 		this.browser = null;
 		this.headers = {};
+		this.cookieSeededHosts = new Set();
 
 		logger.info('init plugin', { launchOptions, scrollToBottom });
 	}
@@ -22,14 +25,25 @@ class PuppeteerPlugin {
 			this.browser = await puppeteer.launch(this.launchOptions);
 		});
 
-		registerAction('beforeRequest', async ({requestOptions}) => {
-			if (hasValues(requestOptions.headers)) {
-				this.headers = Object.assign({}, requestOptions.headers);
+		registerAction('beforeRequest', async ({resource, requestOptions}) => {
+			const url = resource.getUrl();
+			const headers = Object.assign({}, requestOptions.headers);
+
+			await this.seedBrowserCookies(url, headers);
+			await this.applyBrowserCookies(url, headers);
+
+			if (hasValues(headers)) {
+				// puppeteer pages receive cookies from the browser jar, not from headers,
+				// so that Cookie is not leaked to third-party requests made by the page
+				this.headers = omitCookieHeader(headers);
 			}
-			return {requestOptions};
+
+			return {requestOptions: Object.assign({}, requestOptions, {headers})};
 		});
 
 		registerAction('afterResponse', async ({response}) => {
+			await this.storeResponseCookies(response);
+
 			const contentType = response.headers['content-type'];
 			const isHtml = contentType && contentType.split(';')[0] === 'text/html';
 			if (isHtml) {
@@ -65,12 +79,92 @@ class PuppeteerPlugin {
 
 		registerAction('afterFinish', () => this.browser && this.browser.close());
 	}
+
+	/**
+	 * Sets cookies from the configured Cookie request header into the browser jar,
+	 * so puppeteer pages send them too. Done once per host - afterwards the jar,
+	 * which receives rotated/refreshed cookies, is the source of truth.
+	 * See https://github.com/website-scraper/website-scraper-puppeteer/issues/115
+	 */
+	async seedBrowserCookies (url, headers) {
+		const hostname = new URL(url).hostname;
+		if (this.cookieSeededHosts.has(hostname)) {
+			return;
+		}
+		this.cookieSeededHosts.add(hostname);
+
+		const cookieHeader = getCookieHeader(headers);
+		if (!cookieHeader) {
+			return;
+		}
+
+		const cookies = parseCookieHeader(cookieHeader)
+			.map(({name, value}) => ({name, value, domain: hostname, path: '/'}));
+		if (cookies.length > 0) {
+			logger.info(`seed browser cookies for host ${hostname}`, cookies.map(cookie => cookie.name));
+			await this.browser.setCookie(...cookies);
+		}
+	}
+
+	/**
+	 * Replaces the request Cookie header with current cookies from the browser jar.
+	 * Pages opened in puppeteer may rotate session cookies (via Set-Cookie or js),
+	 * which invalidates the initially configured ones.
+	 */
+	async applyBrowserCookies (url, headers) {
+		const cookies = (await this.browser.cookies()).filter(cookie => cookieMatchesUrl(cookie, url));
+		if (cookies.length > 0) {
+			deleteCookieHeader(headers);
+			headers.cookie = serializeCookies(cookies);
+		}
+	}
+
+	/**
+	 * Stores Set-Cookie headers from plain HTTP responses into the browser jar,
+	 * so cookies set on non-html resources are not lost either.
+	 */
+	async storeResponseCookies (response) {
+		const setCookieHeaders = response.headers['set-cookie'];
+		if (!setCookieHeaders || setCookieHeaders.length === 0) {
+			return;
+		}
+
+		const cookies = setCookieHeaders
+			.map(setCookieHeader => parseSetCookieHeader(setCookieHeader, response.url))
+			.filter(Boolean);
+		const now = Date.now() / 1000;
+		const alive = cookies.filter(cookie => cookie.expires === undefined || cookie.expires > now);
+		const expired = cookies.filter(cookie => cookie.expires !== undefined && cookie.expires <= now);
+
+		if (alive.length > 0) {
+			await this.browser.setCookie(...alive);
+		}
+		if (expired.length > 0) {
+			await this.browser.deleteCookie(...expired);
+		}
+	}
 }
 
 function hasValues (obj) {
 	return obj && Object.keys(obj).length > 0;
 }
 
+function getCookieHeader (headers) {
+	const key = Object.keys(headers).find(headerName => headerName.toLowerCase() === 'cookie');
+	return key ? headers[key] : null;
+}
+
+function deleteCookieHeader (headers) {
+	Object.keys(headers)
+		.filter(headerName => headerName.toLowerCase() === 'cookie')
+		.forEach(headerName => delete headers[headerName]);
+}
+
+function omitCookieHeader (headers) {
+	const result = Object.assign({}, headers);
+	deleteCookieHeader(result);
+	return result;
+}
 
 async function scrollToBottom (page, timeout, viewportN) {
 	logger.info(`scroll puppeteer page to bottom ${viewportN} times with timeout = ${timeout}`);

--- a/package.json
+++ b/package.json
@@ -16,8 +16,9 @@
     "html"
   ],
   "dependencies": {
+    "@website-scraper/puppeteer-version-wrapper": "^1.0.0",
     "debug": "^4.1.1",
-    "@website-scraper/puppeteer-version-wrapper": "^1.0.0"
+    "set-cookie-parser": "^3.1.2"
   },
   "peerDependencies": {
     "website-scraper": "^6.0.0"

--- a/test/cookies.test.js
+++ b/test/cookies.test.js
@@ -1,5 +1,5 @@
 import { expect } from 'chai';
-import { parseCookieHeader, parseSetCookieHeader, cookieMatchesUrl, serializeCookies } from '../lib/cookies.js';
+import { parseCookieHeader, parseSetCookieHeader, cookieMatchesUrl, serializeCookies, getCookieHeader, deleteCookieHeader } from '../lib/cookies.js';
 
 describe('Cookies', () => {
 	describe('parseCookieHeader', () => {
@@ -60,32 +60,50 @@ describe('Cookies', () => {
 	});
 
 	describe('cookieMatchesUrl', () => {
+		const matches = (cookie, url) => cookieMatchesUrl(cookie, new URL(url));
+
 		it('should match host-only cookies only on the exact host', () => {
 			const cookie = { name: 'a', value: '1', domain: 'example.com', path: '/' };
-			expect(cookieMatchesUrl(cookie, 'http://example.com/page')).to.eql(true);
-			expect(cookieMatchesUrl(cookie, 'http://sub.example.com/page')).to.eql(false);
-			expect(cookieMatchesUrl(cookie, 'http://other.com/page')).to.eql(false);
+			expect(matches(cookie, 'http://example.com/page')).to.eql(true);
+			expect(matches(cookie, 'http://sub.example.com/page')).to.eql(false);
+			expect(matches(cookie, 'http://other.com/page')).to.eql(false);
 		});
 
 		it('should match domain cookies on subdomains', () => {
 			const cookie = { name: 'a', value: '1', domain: '.example.com', path: '/' };
-			expect(cookieMatchesUrl(cookie, 'http://example.com/')).to.eql(true);
-			expect(cookieMatchesUrl(cookie, 'http://sub.example.com/')).to.eql(true);
-			expect(cookieMatchesUrl(cookie, 'http://badexample.com/')).to.eql(false);
+			expect(matches(cookie, 'http://example.com/')).to.eql(true);
+			expect(matches(cookie, 'http://sub.example.com/')).to.eql(true);
+			expect(matches(cookie, 'http://badexample.com/')).to.eql(false);
 		});
 
 		it('should match paths on segment boundaries', () => {
 			const cookie = { name: 'a', value: '1', domain: 'example.com', path: '/shop' };
-			expect(cookieMatchesUrl(cookie, 'http://example.com/shop')).to.eql(true);
-			expect(cookieMatchesUrl(cookie, 'http://example.com/shop/cart')).to.eql(true);
-			expect(cookieMatchesUrl(cookie, 'http://example.com/shopping')).to.eql(false);
-			expect(cookieMatchesUrl(cookie, 'http://example.com/')).to.eql(false);
+			expect(matches(cookie, 'http://example.com/shop')).to.eql(true);
+			expect(matches(cookie, 'http://example.com/shop/cart')).to.eql(true);
+			expect(matches(cookie, 'http://example.com/shopping')).to.eql(false);
+			expect(matches(cookie, 'http://example.com/')).to.eql(false);
 		});
 
 		it('should not send secure cookies over http', () => {
 			const cookie = { name: 'a', value: '1', domain: 'example.com', path: '/', secure: true };
-			expect(cookieMatchesUrl(cookie, 'http://example.com/')).to.eql(false);
-			expect(cookieMatchesUrl(cookie, 'https://example.com/')).to.eql(true);
+			expect(matches(cookie, 'http://example.com/')).to.eql(false);
+			expect(matches(cookie, 'https://example.com/')).to.eql(true);
+		});
+	});
+
+	describe('getCookieHeader', () => {
+		it('should find the Cookie header case-insensitively', () => {
+			expect(getCookieHeader({ Cookie: 'a=1' })).to.eql('a=1');
+			expect(getCookieHeader({ cookie: 'a=1' })).to.eql('a=1');
+			expect(getCookieHeader({ Accept: 'text/html' })).to.eql(null);
+		});
+	});
+
+	describe('deleteCookieHeader', () => {
+		it('should delete the Cookie header case-insensitively', () => {
+			const headers = { Cookie: 'a=1', cookie: 'b=2', Accept: 'text/html' };
+			deleteCookieHeader(headers);
+			expect(headers).to.eql({ Accept: 'text/html' });
 		});
 	});
 

--- a/test/cookies.test.js
+++ b/test/cookies.test.js
@@ -1,0 +1,98 @@
+import { expect } from 'chai';
+import { parseCookieHeader, parseSetCookieHeader, cookieMatchesUrl, serializeCookies } from '../lib/cookies.js';
+
+describe('Cookies', () => {
+	describe('parseCookieHeader', () => {
+		it('should parse name=value pairs', () => {
+			expect(parseCookieHeader('a=1; b=2')).to.eql([
+				{ name: 'a', value: '1' },
+				{ name: 'b', value: '2' }
+			]);
+		});
+
+		it('should keep = characters inside values', () => {
+			expect(parseCookieHeader('token=abc=def')).to.eql([{ name: 'token', value: 'abc=def' }]);
+		});
+
+		it('should skip malformed pairs', () => {
+			expect(parseCookieHeader('malformed; a=1; =nameless')).to.eql([{ name: 'a', value: '1' }]);
+		});
+	});
+
+	describe('parseSetCookieHeader', () => {
+		const url = 'https://example.com/shop/cart';
+
+		it('should default domain and path from the request url', () => {
+			expect(parseSetCookieHeader('session=xyz', url)).to.eql({
+				name: 'session',
+				value: 'xyz',
+				domain: 'example.com',
+				path: '/shop'
+			});
+		});
+
+		it('should parse attributes', () => {
+			const cookie = parseSetCookieHeader('session=xyz; Domain=example.com; Path=/; Secure; HttpOnly', url);
+			expect(cookie).to.include({
+				name: 'session',
+				value: 'xyz',
+				domain: '.example.com',
+				path: '/',
+				secure: true,
+				httpOnly: true
+			});
+		});
+
+		it('should prefer Max-Age over Expires', () => {
+			const cookie = parseSetCookieHeader('a=1; Expires=Wed, 01 Jan 2020 00:00:00 GMT; Max-Age=60', url);
+			expect(cookie.expires).to.be.greaterThan(Date.now() / 1000);
+		});
+
+		it('should parse Expires into a unix timestamp', () => {
+			const cookie = parseSetCookieHeader('a=1; Expires=Wed, 01 Jan 2020 00:00:00 GMT', url);
+			expect(cookie.expires).to.eql(Date.parse('Wed, 01 Jan 2020 00:00:00 GMT') / 1000);
+		});
+
+		it('should return null for malformed headers', () => {
+			expect(parseSetCookieHeader('malformed', url)).to.eql(null);
+			expect(parseSetCookieHeader('=nameless', url)).to.eql(null);
+		});
+	});
+
+	describe('cookieMatchesUrl', () => {
+		it('should match host-only cookies only on the exact host', () => {
+			const cookie = { name: 'a', value: '1', domain: 'example.com', path: '/' };
+			expect(cookieMatchesUrl(cookie, 'http://example.com/page')).to.eql(true);
+			expect(cookieMatchesUrl(cookie, 'http://sub.example.com/page')).to.eql(false);
+			expect(cookieMatchesUrl(cookie, 'http://other.com/page')).to.eql(false);
+		});
+
+		it('should match domain cookies on subdomains', () => {
+			const cookie = { name: 'a', value: '1', domain: '.example.com', path: '/' };
+			expect(cookieMatchesUrl(cookie, 'http://example.com/')).to.eql(true);
+			expect(cookieMatchesUrl(cookie, 'http://sub.example.com/')).to.eql(true);
+			expect(cookieMatchesUrl(cookie, 'http://badexample.com/')).to.eql(false);
+		});
+
+		it('should match paths on segment boundaries', () => {
+			const cookie = { name: 'a', value: '1', domain: 'example.com', path: '/shop' };
+			expect(cookieMatchesUrl(cookie, 'http://example.com/shop')).to.eql(true);
+			expect(cookieMatchesUrl(cookie, 'http://example.com/shop/cart')).to.eql(true);
+			expect(cookieMatchesUrl(cookie, 'http://example.com/shopping')).to.eql(false);
+			expect(cookieMatchesUrl(cookie, 'http://example.com/')).to.eql(false);
+		});
+
+		it('should not send secure cookies over http', () => {
+			const cookie = { name: 'a', value: '1', domain: 'example.com', path: '/', secure: true };
+			expect(cookieMatchesUrl(cookie, 'http://example.com/')).to.eql(false);
+			expect(cookieMatchesUrl(cookie, 'https://example.com/')).to.eql(true);
+		});
+	});
+
+	describe('serializeCookies', () => {
+		it('should serialize cookies into a Cookie header value', () => {
+			const cookies = [{ name: 'a', value: '1' }, { name: 'b', value: '2' }];
+			expect(serializeCookies(cookies)).to.eql('a=1; b=2');
+		});
+	});
+});

--- a/test/puppeteer-plugin.test.js
+++ b/test/puppeteer-plugin.test.js
@@ -113,7 +113,7 @@ describe('Puppeteer plugin test', () => {
 // (like WordPress heartbeat / WooCommerce fragments do). Rotation invalidates
 // the previous token, and presenting a stale token destroys the whole session
 // (like WordPress security plugins do on suspected session hijacking).
-function startSessionRotatingWebserver(port) {
+function startSessionRotatingWebserver (port) {
 	const validTokens = new Set(['token-1']);
 	const seenTokens = new Set(['token-1']);
 	let tokenCounter = 1;

--- a/test/puppeteer-plugin.test.js
+++ b/test/puppeteer-plugin.test.js
@@ -84,6 +84,12 @@ describe('Puppeteer plugin test', () => {
 		it('should stay logged in on subsequent pages', () => {
 			expect(files.page2).to.contain('LOGGED-IN');
 		});
+
+		it('should use the rotated cookie for subsequent website-scraper requests', () => {
+			const scraperRequests = sessionServer.requestLog.filter(request => request.url === '/page2.html' && !request.fromBrowser);
+			expect(scraperRequests).to.have.lengthOf(1);
+			expect(scraperRequests[0].cookie).to.eql('session=token-2');
+		});
 	});
 
 	describe('CJK content with charset only in meta tag', () => {
@@ -117,10 +123,18 @@ function startSessionRotatingWebserver (port) {
 	const validTokens = new Set(['token-1']);
 	const seenTokens = new Set(['token-1']);
 	let tokenCounter = 1;
+	const requestLog = [];
 
 	const server = http.createServer((req, res) => {
 		const tokenMatch = (req.headers.cookie || '').match(/session=([^;]+)/);
 		const token = tokenMatch ? tokenMatch[1] : null;
+
+		requestLog.push({
+			url: req.url,
+			cookie: req.headers.cookie || null,
+			// requests made by the puppeteer page vs by website-scraper itself
+			fromBrowser: (req.headers['user-agent'] || '').includes('HeadlessChrome')
+		});
 
 		if (token && seenTokens.has(token) && !validTokens.has(token)) {
 			validTokens.clear(); // stale token reuse -> destroy session
@@ -148,6 +162,7 @@ function startSessionRotatingWebserver (port) {
 		</body></html>`);
 	});
 
+	server.requestLog = requestLog;
 	return server.listen(port);
 }
 

--- a/test/puppeteer-plugin.test.js
+++ b/test/puppeteer-plugin.test.js
@@ -43,6 +43,49 @@ describe('Puppeteer plugin test', () => {
 		});
 	});
 
+	// Regression test for https://github.com/website-scraper/website-scraper-puppeteer/issues/115
+	// The page js rotates the session cookie; the rotated cookie must be used
+	// for subsequent requests instead of the initially configured one.
+	describe('Session cookie rotated by page js', () => {
+		const SESSION_SERVER_PORT = 4568;
+		let sessionServer, files;
+
+		before('start session webserver', () => sessionServer = startSessionRotatingWebserver(SESSION_SERVER_PORT));
+		after('stop session webserver', () => sessionServer.close());
+
+		before('scrape website', async () => {
+			await scrape({
+				urls: [`http://localhost:${SESSION_SERVER_PORT}/`],
+				directory: directory,
+				recursive: true,
+				requestConcurrency: 1,
+				request: {
+					headers: { Cookie: 'session=token-1' }
+				},
+				urlFilter: url => url.startsWith(`http://localhost:${SESSION_SERVER_PORT}`),
+				plugins: [ new PuppeteerPlugin({
+					// wait for the session-rotating fetch() to complete before the page is closed
+					gotoOptions: { waitUntil: 'networkidle0' }
+				}) ]
+			});
+		});
+		before('get content from files', () => {
+			files = {
+				index: fs.readFileSync(`${directory}/index.html`).toString(),
+				page2: fs.readFileSync(`${directory}/page2.html`).toString()
+			};
+		});
+		after('delete dir', () => fs.removeSync(directory));
+
+		it('should stay logged in on the first page', () => {
+			expect(files.index).to.contain('LOGGED-IN');
+		});
+
+		it('should stay logged in on subsequent pages', () => {
+			expect(files.page2).to.contain('LOGGED-IN');
+		});
+	});
+
 	describe('CJK content with charset only in meta tag', () => {
 		let cjkResult, cjkContent;
 
@@ -65,6 +108,48 @@ describe('Puppeteer plugin test', () => {
 		});
 	});
 });
+
+// Simulates a website which rotates the session cookie via an ajax call
+// (like WordPress heartbeat / WooCommerce fragments do). Rotation invalidates
+// the previous token, and presenting a stale token destroys the whole session
+// (like WordPress security plugins do on suspected session hijacking).
+function startSessionRotatingWebserver(port) {
+	const validTokens = new Set(['token-1']);
+	const seenTokens = new Set(['token-1']);
+	let tokenCounter = 1;
+
+	const server = http.createServer((req, res) => {
+		const tokenMatch = (req.headers.cookie || '').match(/session=([^;]+)/);
+		const token = tokenMatch ? tokenMatch[1] : null;
+
+		if (token && seenTokens.has(token) && !validTokens.has(token)) {
+			validTokens.clear(); // stale token reuse -> destroy session
+		}
+		const loggedIn = token && validTokens.has(token);
+
+		if (req.url === '/refresh') {
+			if (loggedIn) {
+				validTokens.delete(token);
+				const newToken = `token-${++tokenCounter}`;
+				validTokens.add(newToken);
+				seenTokens.add(newToken);
+				res.setHeader('Set-Cookie', `session=${newToken}; Path=/`);
+			}
+			res.setHeader('Content-Type', 'application/json');
+			res.end(JSON.stringify({ ok: loggedIn }));
+			return;
+		}
+
+		res.setHeader('Content-Type', 'text/html');
+		const status = loggedIn ? 'LOGGED-IN' : 'LOGGED-OUT';
+		res.end(`<html><body><h1>${status}</h1>
+			<a href="/page2.html">page2</a>
+			<script>fetch('/refresh');</script>
+		</body></html>`);
+	});
+
+	return server.listen(port);
+}
 
 function startWebserver(port = 3000) {
 	const serve = serveStatic('./test/mock', {'index': ['index.html']});


### PR DESCRIPTION
Fixes #115

## Root cause

The plugin had a one-way, static cookie flow, and the browser broke it by executing the website's js:

1. website-scraper's plain HTTP request sends the configured `Cookie` header — page 1 is logged in.
2. The plugin re-opens that page in puppeteer, which runs the page's js. On a WordPress/WooCommerce site that means heartbeat/ajax calls, which commonly **rotate the session cookie** (`Set-Cookie` with a new token, old one invalidated).
3. The new cookie landed only in the browser's cookie jar. The scraper's `request.headers.Cookie` is a frozen string, so every subsequent request presented the invalidated token → "logged out" from the second request on.

Without the plugin no js ever runs, the session never rotates, and the static cookie stays valid — which is exactly why the reporter's plugin-free config worked.

Reproduced with a mock server that rotates the session token via a js-triggered `fetch('/refresh')` and destroys the session when a stale token is presented (as WordPress security plugins do on suspected session hijacking): first page saved logged-in, second page saved logged-out — the exact reported symptom. The scenario is now a regression test.

## Fix

Make the browser cookie jar the single source of truth:

- at `beforeStart`, cookies from the configured `Cookie` header are seeded into the jar for the scraped urls' hosts (as domain cookies, so subdomains are covered) — and only for those hosts, so the user's session cookies are not sent to other domains the crawl encounters
- `beforeRequest` rebuilds the outgoing `Cookie` header from the current jar contents, so plain HTTP requests pick up rotated/refreshed cookies
- `afterResponse` feeds `Set-Cookie` headers from plain HTTP responses into the jar, so cookies set on non-html resources are not lost either
- Set-Cookie parsing is delegated to the zero-dependency [`set-cookie-parser`](https://www.npmjs.com/package/set-cookie-parser) package (with `decodeValues: false` so values round-trip verbatim); the CDP-specific mapping (leading-dot domain convention, RFC 6265 default path / matching, Max-Age precedence) lives in the new `lib/cookies.js`, covered by unit tests
- `requestOptions` is cloned instead of mutating website-scraper's shared `options.request` object

## Behavior change to note

`Cookie` is no longer passed to puppeteer via `setExtraHTTPHeaders`. Previously Chrome attached that header to **every** request the page made, including third-party/cross-origin ones (a cookie leak); its precedence against the jar was also Chrome-version-dependent. Cookies now come from the jar with normal browser scoping.

## Testing

- new regression test with a session-rotating server: fails on master (page 2 saved as `LOGGED-OUT`), passes with this change
- new unit tests for `lib/cookies.js`
- full suite: 21 passing, eslint clean, qlty green

🤖 Generated with [Claude Code](https://claude.com/claude-code)