### PR TITLE
ci: declare mocha env for test files in eslint config

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -5,6 +5,10 @@ parserOptions:
 env:
   node: true
   es6: true
+overrides:
+  - files: ["test/**"]
+    env:
+      mocha: true
 rules:
   consistent-return: "error"
   curly: "error"


### PR DESCRIPTION
Adds an eslint override declaring the mocha environment for `test/**`, so qlty's eslint check does not report `no-undef` for `describe`/`it`/`before`/`after` in test files (as seen on #175 — `npm run eslint` only lints `lib/**`, so this never surfaced locally or in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)